### PR TITLE
fix(ketcher-react): adjusting top toolbar collapse limit to account for the minimize button

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/toolbars/TopToolbar/TopToolbar.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/TopToolbar/TopToolbar.tsx
@@ -73,6 +73,7 @@ export interface PanelProps {
 
 const collapseLimit = 650;
 const CUSTOM_BUTTON_ADDITIONAL_WIDTH = 40;
+const MINIMIZE_BUTTON_AND_DIVIDER_ADDITIONAL_WIDTH = 120;
 
 const ControlsPanel = styled('div')`
   display: flex;
@@ -178,7 +179,9 @@ export const TopToolbar = ({
 
   const collapseLimitWithCustomButtons = useMemo(() => {
     return (
-      collapseLimit + customButtons.length * CUSTOM_BUTTON_ADDITIONAL_WIDTH
+      collapseLimit +
+      customButtons.length * CUSTOM_BUTTON_ADDITIONAL_WIDTH +
+      MINIMIZE_BUTTON_AND_DIVIDER_ADDITIONAL_WIDTH
     );
   }, [customButtons.length]);
 


### PR DESCRIPTION
Merge of the new fix from  custom-stable-v3.1.0 into custom-stable-v3.1.0-with-app